### PR TITLE
Fix/user id navigator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ yarn-error.*
 app-example
 package-lock.json
 package
+
+.idea
+.gradle

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,47 +1,37 @@
 import { Tabs } from "expo-router";
 import { Platform } from "react-native";
-import { HapticTab } from "@/components/HapticTab";
-import { IconSymbol } from "@/components/ui/IconSymbol";
-import TabBarBackground from "@/components/ui/TabBarBackground";
-import { Colors } from "@/constants/Colors";
 import Header from "@/components/Header";
+import TabBarBackground from "@/components/ui/TabBarBackground";
+import { IconSymbol } from "@/components/ui/IconSymbol";
 
 export default function TabLayout() {
-  console.log("TabLayout rendering");
   return (
-      <Tabs
-        screenOptions={{
-          tabBarActiveTintColor: Colors.light.tint,
-          headerShown: true,
-          header: () => <Header />,
-          tabBarButton: HapticTab,
-          tabBarBackground: TabBarBackground,
-          tabBarStyle: Platform.select({
-            ios: {
-              position: "absolute",
-            },
-            default: {},
-          }),
+    <Tabs
+      screenOptions={{
+        header: () => <Header />,
+        tabBarActiveTintColor: "#1EBD7B",
+        tabBarBackground: TabBarBackground,
+        tabBarStyle: Platform.select({ ios: { position: "absolute" } }),
+      }}
+    >
+      <Tabs.Screen
+        name="index"
+        options={{
+          title: "Home",
+          tabBarIcon: ({ color }) => (
+            <IconSymbol name="house.fill" size={24} color={color} />
+          ),
         }}
-      >
-        <Tabs.Screen
-          name="index"
-          options={{
-            title: "Home",
-            tabBarIcon: ({ color }) => (
-              <IconSymbol size={28} name="house.fill" color={color} />
-            ),
-          }}
-        />
-        <Tabs.Screen
-          name="explore"
-          options={{
-            title: "Explore",
-            tabBarIcon: ({ color }) => (
-              <IconSymbol size={28} name="paperplane.fill" color={color} />
-            ),
-          }}
-        />
-      </Tabs>
+      />
+      <Tabs.Screen
+        name="explore"
+        options={{
+          title: "Explore",
+          tabBarIcon: ({ color }) => (
+            <IconSymbol name="paperplane.fill" size={24} color={color} />
+          ),
+        }}
+      />
+    </Tabs>
   );
 }

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -51,7 +51,6 @@ export default function RootLayout() {
                         position="bottom"/>
                         <Stack
                           screenOptions={{
-                            headerShown: true,
                             header: () => <Header />,
                           }}
                         >
@@ -77,8 +76,8 @@ export default function RootLayout() {
                           />
                           <Stack.Screen
                             name="dashboard/[userId]"
-                            options={{ headerShown: true }}
-                          />
+                            options={{ title: "Dashboard" }}
+                            />
                           <Stack.Screen
                             name="+not-found"
                             options={{ headerShown: true }}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect } from "react";
-import { View, Text, TouchableOpacity, Image,StatusBar } from "react-native";
+import { View, Text, TouchableOpacity, Image, StatusBar } from "react-native";
 import { useRouter } from "expo-router";
 import { useAuth } from "../contexts/AuthContext";
 import { useThemeColor } from "@/hooks/useThemeColor";
@@ -13,7 +13,7 @@ const Header = () => {
 
   const fetchProfile = useCallback(async () => {
     if (!isLoggedIn || !user?.id || user.profile_image) {
-      return;
+      return null;
     }
     await getProfile(user.id);
   }, [isLoggedIn, user?.id, user?.profile_image, getProfile]);
@@ -23,13 +23,18 @@ const Header = () => {
   }, [fetchProfile]);
 
   const handleNavigation = () => {
+    console.log("🚀 handleNavigation called");
+
     if (isLoggedIn && user?.id) {
+      console.log("✅ going to dashboard");
+
       router.replace(`/dashboard/${user.id}`);
     } else {
+      console.log("❌ going to login");
+
       router.push("/login");
     }
   };
-
 
   return (
     <View

--- a/components/login/LoginForm.tsx
+++ b/components/login/LoginForm.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { useAuth } from "../../contexts/AuthContext";
 import { Text, TouchableOpacity, View } from "react-native";
-import { useRouter } from "expo-router";
+import { usePathname, useRouter } from "expo-router";
 import Toast from "react-native-toast-message";
 import { useThemeColor } from "@/hooks/useThemeColor";
 import GoBackArrow from "@/assets/icons/GoBackArrow";
@@ -10,11 +10,12 @@ import GlobalButton from "../ui/GlobalButton";
 
 const LoginForm = () => {
   const router = useRouter();
+  const pathname = usePathname();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [emailError, setEmailError] = useState("");
   const [passwordError, setPasswordError] = useState("");
-  const { login, user } = useAuth();
+  const { login, user, isLoggedIn } = useAuth();
 
   const textColor = useThemeColor({}, "text");
   const primary600 = useThemeColor({}, "primary-600");
@@ -53,14 +54,14 @@ const LoginForm = () => {
   }, [email, password, login]);
 
   useEffect(() => {
-    if (user) {
+    if (isLoggedIn && user && pathname === "/login") {
       Toast.show({
         type: "success",
         text1: `Welcome back, ${user.username}!`,
       });
-      router.push("/");
+      router.replace("/(tabs)");
     }
-  }, [user]);
+  }, [isLoggedIn, user, pathname]);
 
   return (
     <View
@@ -78,7 +79,7 @@ const LoginForm = () => {
           textAlign: "center",
           color: white,
           fontSize: 20,
-          marginBottom:20,
+          marginBottom: 20,
           fontWeight: "bold",
         }}
       >

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -88,12 +88,15 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     const initializeAuth = async () => {
       const storedToken = localStorage.getItem(TOKEN_KEY);
       const storedUser = localStorage.getItem(USER_KEY);
-      if (storedToken && storedUser) {
-        const isValid = await verifyToken(storedToken);
+      if (storedToken && storedUser && storedToken !== token) {
+                const isValid = await verifyToken(storedToken);
         if (isValid) {
-          setToken(storedToken);
-          setUser(JSON.parse(storedUser));
-          setIsLoggedIn(true);
+          const parsedUser = JSON.parse(storedUser);
+        setToken(storedToken);
+        setUser((prev) =>
+          JSON.stringify(prev) === storedUser ? prev : parsedUser
+        );
+        setIsLoggedIn(true);
         } else {
           localStorage.removeItem(TOKEN_KEY);
           localStorage.removeItem(USER_KEY);
@@ -105,8 +108,8 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     };
 
     initializeAuth();
-  }, []);
-
+  }, [token]);
+  
   // Function to verify the current password
   const verifyCurrentPassword = async (
     email: string,


### PR DESCRIPTION
## Description
This change fixes a bug where, after logging in, navigating to other pages (e.g., dashboard/[userId]) always redirects the user back to the home page (/(tabs)/index). The issue was caused by an unconditional redirect in the LoginForm component, which triggered a navigation to the home page whenever the user state changed. The fix modifies the LoginForm.tsx, AuthContext.tsx file to ensure redirects only occur from the login screen (/login) upon successful login.

## Why
The bug occurred because the useEffect hook in LoginForm.tsx was redirecting to the home page (router.push("/")) whenever the user state from AuthContext was updated, regardless of the current page. This behavior disrupted navigation, preventing users from staying on other pages like (tabs)/explore or dashboard/[userId]. To resolve this, the redirect logic was updated to use usePathname from expo-router to check if the current page is /login before triggering a redirect to (tabs). Additionally, router.replace was used instead of router.push to prevent adding the login screen to the navigation stack, ensuring a cleaner navigation experience.

## Testing
- Test Case 1: Log in from the /login screen.
  - Expected: Successfully redirects to (tabs)/index with a "Welcome back" toast message.
  - Result: Pass.
- Test Case 2: Navigate to (tabs)/explore after login.
  - Expected: Stays on (tabs)/explore without redirecting to home.
  - Result: Pass.
- Test Case 3: Navigate to dashboard/[userId] after login.
  - Expected: Stays on dashboard/[userId] without redirecting to home.
  - Result: Pass.
- Test Case 4: Update user profile (triggering user state change) while on (tabs)/explore.
  - Expected: No redirect to home; remains on current page.
  - Result: Pass.

## Linked Issues
Fixes #12 
